### PR TITLE
_qb/guitar/menu/menu_press_any_button.q: add temporary Deluxe text logo

### DIFF
--- a/_qb/guitar/menu/menu_press_any_button.q
+++ b/_qb/guitar/menu/menu_press_any_button.q
@@ -1,0 +1,36 @@
+script create_gh3dx_loaded_toast 
+	CreateScreenElement {
+		Type = TextBlockElement
+		PARENT = pab_container
+		font = text_a6
+		Text = "DELUXE"
+		Dims = (500.0, 200.0)
+		Pos = (619.0, 350.0)
+		just = [LEFT Top]
+		internal_just = [Center Top]
+		rgba = [220 220 220 255]
+		Scale = 0.9
+		Shadow
+        shadow_offs = (3.0, 3.0)
+        shadow_rgba = [110 20 80 250]
+	}
+endscript
+
+script menu_press_any_button_create_obvious_text 
+	create_gh3dx_loaded_toast
+	Text = "PRESS ANY BUTTON TO ROCK..."
+	text_pos = (670.0, 425.0)
+	CreateScreenElement {
+		Type = TextBlockElement
+		PARENT = pab_container
+		font = text_a6
+		Text = <Text>
+		Dims = (500.0, 200.0)
+		Pos = <text_pos>
+		just = [LEFT Top]
+		internal_just = [Center Top]
+		rgba = [215 120 40 255]
+		Scale = 0.7
+		allow_expansion
+	}
+endscript


### PR DESCRIPTION
Since we are unable (for the moment) to replace sprite assets, this is a temporary text logo that will indicate better to the user that GH3DX has been loaded. In the future, I may add a version to the main menu, which (maybe?) can show the version+commit of the mod.