### PR TITLE
fix escaped quotes

### DIFF
--- a/_qb/dx/menu/modifiers_menu.q
+++ b/_qb/dx/menu/modifiers_menu.q
@@ -21,7 +21,7 @@ modifier_options = [
 	{
 		Name = "Song Title Always On"
 		Id = SONG_TITLE
-		Description = "Now you won't have to answer to \"Hey what song is this?\""
+		Description = "Now you won't have to answer to \'Hey what song is this?\'"
 	}
 	{
 		Name = "No Highway Shake"


### PR DESCRIPTION
main reason this is getting pr'd is because as addy has explained, it's not supported by the game but are in debug printf statements. - not fixing the weird comment issue that causes the actions to break for the modifier menu on linux. will have to change actions from linux to windows (maybe)